### PR TITLE
Master

### DIFF
--- a/site_content/examples.py
+++ b/site_content/examples.py
@@ -1,4 +1,4 @@
-from functions import lipsum, random_image, random_article
+from .functions import lipsum, random_image, random_article
 from random import random
 import string
 

--- a/site_content/structure.py
+++ b/site_content/structure.py
@@ -1,4 +1,4 @@
-from pages import Page, Pages, SCSSPage, TemplatePage, FrontPage, CoffeePage
+from .pages import Page, Pages, SCSSPage, TemplatePage, FrontPage, CoffeePage
 from jinja2.utils import generate_lorem_ipsum as lipsum
 import os
 from ordereddict import OrderedDict


### PR DESCRIPTION
Python 3 does no longer support non implicit relative imports (PEP328)
Python 2 uses “from **future** import absolute_import” by default while
Python 3 does not.
