### PR TITLE
Remove top and bottom padding

### DIFF
--- a/src/styles/core_elements/_buttons.scss
+++ b/src/styles/core_elements/_buttons.scss
@@ -16,7 +16,8 @@
 .btn-cta {
   background-image: url("../images/primary-cta-chevron.png") !important;
   background-position: right 11px top 50%;
-  padding: 5px 25px 5px 10px;
+  padding-right: 25px;
+  padding-left: 10px;
 }
 
 .btn-vcard {


### PR DESCRIPTION
It appears that the 5px top and bottom padding is not needed and causes the btn-cta button to be slightly smaller than they should be